### PR TITLE
fixed window settings and vertical padding on windows, adjusted ruler

### DIFF
--- a/src/audio_sys/config_window.rs
+++ b/src/audio_sys/config_window.rs
@@ -146,9 +146,8 @@ impl State {
   }
 
   pub fn view(&self) -> Element<Msg> {
-    let vert = iced::widget::vertical_space().height(20);
     let cbx = combo_box(&self.hosts,"pick a host",self.selected_host.as_ref(),Msg::HostSelect);
-    let col = column![vert,cbx];
+    let col = column![cbx];
 
     let col = if let Some(s) = self.out_devs.as_ref() {
       let out_box = combo_box(s,"",self.out_dev.as_ref(),Msg::OutSelect);

--- a/src/editor_window.rs
+++ b/src/editor_window.rs
@@ -211,7 +211,6 @@ impl Win {
     .into();
 
     column![
-      iced::widget::vertical_space().height(25),
       container(waveform.map(Msg::SndView)).height(600).style(|_|self.skin.waveform_box()),
       row![
         column![

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,7 @@ const WINSET : iced::window::Settings = iced::window::Settings {
   platform_specific: iced::window::settings::PlatformSpecific{
     title_hidden: false,
     titlebar_transparent: false,
-    fullsize_content_view: true
+    fullsize_content_view: false 
   },
   exit_on_close_request: true
 };

--- a/src/widgets/snd_viewer/canvas.rs
+++ b/src/widgets/snd_viewer/canvas.rs
@@ -307,8 +307,7 @@ impl<'a> canvas::Program<Msg> for SndCanvas<'a> {
     if let Some(r) = self.ruler {
       const TK_H:f32 = 24.0;
 
-      //there is some weird stuff with the box height
-      let top_y = 0.0;
+      let top_y = 1.0;
       let btm_y = bounds.height-1.0;
       
 


### PR DESCRIPTION
previously the window settings made it so the title bar covered up the first 25 or so pixels of each window, causing me to add a padding space to the top of each of them, I corrected those frame settings and got rid of those pads.